### PR TITLE
Simplify pivot view and improve totals styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
 
 <!-- Libs -->
 <script src="https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.0/dist/chart.umd.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
 
 <style>
 :root{
   --bg:#0f1216; --panel:#161b22; --text:#e7ecf3; --muted:#9aa6b2; --accent:#2563eb;
   --ok:#36d399; --danger:#ef4444; --border:#273043; --chip:#1c2432;
+  --border-strong:color-mix(in srgb, var(--text) 40%, var(--border));
   --shadow:0 8px 24px rgba(0,0,0,.35);
   --header-grad: linear-gradient(180deg, rgba(255,255,255,.03) 0%, rgba(255,255,255,0) 100%);
   --btnText:#fff;
@@ -24,6 +24,7 @@
 body.light{
   --bg:#f7f9fc; --panel:#ffffff; --text:#0f172a; --muted:#475569; --accent:#2563eb;
   --ok:#059669; --danger:#dc2626; --border:#e2e8f0; --chip:#eef2f7;
+  --border-strong:color-mix(in srgb, var(--text) 35%, var(--border));
   --shadow:0 6px 18px rgba(15,23,42,.08);
   --header-grad: linear-gradient(180deg, rgba(15,23,42,.06) 0%, rgba(15,23,42,0) 100%);
   --btnText:#0f172a;
@@ -59,16 +60,13 @@ body:not(.has-data) #emptyState{display:flex;align-items:center;justify-content:
 body.has-data #emptyState{display:none}
 body:not(.has-data) #topLine,
 body:not(.has-data) #kpiSection,
-body:not(.has-data) #chartsSection,
 body:not(.has-data) #pivotSection{display:none !important}
 
 /* Topline */
 .topline{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px clamp(14px,3vw,28px);flex-wrap:wrap}
 .topline-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:flex-end}
-.view-toggle-btn{display:inline-flex;align-items:center;gap:6px;border-radius:10px;padding:8px 12px;white-space:nowrap;font-weight:600;font-size:13px}
 .pill{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;background:var(--chip);border:1px solid var(--border);border-radius:999px;color:var(--muted)}
 .months-wrap{display:flex;align-items:center;gap:6px}
-#viewToggleBtn{margin-left:auto}
 #clearMonth{display:none;border-radius:10px;padding:6px 9px}
 .month-dd{position:relative}
 .month-dd .dd-control{min-width:160px;display:flex;align-items:center;justify-content:space-between;gap:8px;padding:8px 10px;border:1px solid var(--border);border-radius:10px;background:var(--panel);cursor:pointer}
@@ -86,36 +84,32 @@ body:not(.has-data) #pivotSection{display:none !important}
 .kpi.small .value{font-size:20px}
 .kpi.small{padding-right:6px}
 
-/* Charts: grid layout */
-.charts{padding:4px clamp(14px,3vw,26px) 18px;display:grid;grid-template-columns:repeat(12,1fr);gap:var(--chartsGap);align-items:start}
-.chart-card{position:relative;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px 12px 10px;box-shadow:var(--shadow);overflow:hidden;display:flex;flex-direction:column}
-#chartLeft{grid-column:span 6}
-#chartRight{grid-column:span 6}
-#chartCat{grid-column:span 12}
-.chart-title{font-weight:700;margin-bottom:8px;color:var(--muted)}
-.chart-body{flex:1;min-height:0;position:relative}
-canvas{position:absolute;inset:0;display:block;width:100%;height:100%}
-
 /* Pivot table */
 .pivot{padding:6px clamp(14px,3vw,26px) 20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--chartsGap);align-items:start}
+.chart-card{position:relative;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px 12px 10px;box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:hidden}
+.chart-title{font-weight:700;margin-bottom:8px;color:var(--muted)}
 .pivot-card{margin:0;width:100%}
 .pivot-card+.pivot-card{margin-top:0}
-.pivot-body{margin-top:10px;overflow-x:auto}
+.pivot-body{margin-top:10px;overflow:auto;max-height:clamp(360px,55vh,520px);position:relative;border-radius:10px;padding-bottom:4px;background:var(--panel)}
 .pivot-table{width:100%;border-collapse:collapse;min-width:320px;font-variant-numeric:tabular-nums}
-.pivot-table thead th{text-align:left;padding:10px 12px;border-bottom:1px solid var(--border);font-weight:700;color:var(--muted);font-size:12.5px;letter-spacing:.3px;text-transform:uppercase}
+.pivot-table thead th{padding:10px 12px;border-bottom:2px solid var(--border-strong);font-weight:700;color:var(--muted);font-size:12.5px;letter-spacing:.3px;text-transform:uppercase;position:sticky;top:0;background:var(--panel);z-index:3;text-align:right}
+.pivot-table thead th:first-child{text-align:left}
 .pivot-table tbody th{padding:10px 12px;border-bottom:1px solid var(--border);text-align:left;font-weight:600;color:var(--text);white-space:nowrap}
 .pivot-table tbody td{padding:10px 12px;border-bottom:1px solid var(--border);vertical-align:middle}
 .pivot-table tbody tr:hover{background:var(--chip)}
 .pivot-table td.pivot-num{text-align:right;font-weight:600;font-variant-numeric:tabular-nums}
-.pivot-table tr.pivot-total td.pivot-num{font-weight:700}
+.pivot-table tfoot th,.pivot-table tfoot td{padding:12px;border-top:4px double var(--border-strong);border-bottom:0;font-weight:800;background:var(--panel);position:sticky;bottom:0;z-index:2}
+.pivot-table tfoot th{text-align:left}
+.pivot-table tfoot td{text-align:right}
+.pivot-table tfoot td.pivot-acos{padding-right:12px}
+.pivot-table tfoot td .pivot-amount-total{font-weight:800}
 .pivot-table td.pivot-acos{color:var(--text);vertical-align:middle;text-align:right}
 .pivot-table td.pivot-acos .pivot-amount{display:inline-block;min-width:56px;text-align:right;font-weight:600}
-.pivot-table tr.pivot-total td.pivot-acos .pivot-amount{font-weight:700}
 .pivot-table td.pivot-acos.pivot-acos-empty{color:var(--muted)}
 .pivot-acos-wrap{display:flex;align-items:center;gap:12px;width:100%}
 .pivot-acos-wrap .pivot-bar{flex:1}
 .pivot-bar-fill.acos{background:linear-gradient(90deg,rgba(239,68,68,.9),rgba(220,38,38,.95))}
-.pivot-table tr.pivot-total th,.pivot-table tr.pivot-total td{font-weight:700;border-top:2px solid var(--border)}
+.pivot-table tr.pivot-total th,.pivot-table tr.pivot-total td{font-weight:800}
 .pivot-empty{text-align:center;padding:24px 12px;color:var(--muted);font-weight:600;letter-spacing:.2px}
 
 .pivot-metric{display:flex;flex-direction:column;gap:6px}
@@ -167,7 +161,7 @@ canvas{position:absolute;inset:0;display:block;width:100%;height:100%}
 .dd-count{text-align:right;color:var(--muted);font-variant-numeric:tabular-nums}
 
 /* responsive */
-@media (max-width:980px){.kpis{grid-template-columns:repeat(4,1fr)} #chartLeft,#chartRight{grid-column:span 12}}
+@media (max-width:980px){.kpis{grid-template-columns:repeat(4,1fr)}}
 @media (max-width:620px){.kpis{grid-template-columns:repeat(2,1fr)}}
 </style>
 </head>
@@ -199,7 +193,6 @@ canvas{position:absolute;inset:0;display:block;width:100%;height:100%}
           <div class="dd-panel"><div id="monthList"></div></div>
         </div>
       </div>
-      <button id="viewToggleBtn" type="button" class="btn-outline view-toggle-btn" hidden title="Toggle between chart and pivot layouts">Show Bars</button>
     </div>
   </div>
 
@@ -217,22 +210,6 @@ canvas{position:absolute;inset:0;display:block;width:100%;height:100%}
   <div class="kpi small"><div class="label">CTR</div><div class="value" id="kpiCTR">—</div></div>
   <div class="kpi"><div class="label">ROAS</div><div class="value" id="kpiROAS">—</div></div>
   <div class="kpi"><div class="label">Avg CPC</div><div class="value" id="kpiAvgCPC">—</div></div>
-</section>
-
-  <!-- Charts -->
-  <section class="charts" id="chartsSection" hidden>
-  <div class="chart-card" id="chartLeft">
-    <div class="chart-title">Spend, Sales & ACOS by Store</div>
-    <div class="chart-body"><canvas id="barStore"></canvas></div>
-  </div>
-  <div class="chart-card" id="chartRight">
-    <div class="chart-title">Spend, Sales & ACOS by LO</div>
-    <div class="chart-body"><canvas id="barLo"></canvas></div>
-  </div>
-  <div class="chart-card" id="chartCat">
-    <div class="chart-title">Spend, Sales & ACOS by Category</div>
-    <div class="chart-body"><canvas id="barCat"></canvas></div>
-  </div>
 </section>
 
   <!-- Pivot Table -->
@@ -318,8 +295,8 @@ function parseNumber(v){ if(v==null || v==="") return 0; if(typeof v==='number' 
 function clampPanelRight(panel){ panel.style.left='0'; panel.style.right='auto'; const rect=panel.getBoundingClientRect(), vw=document.documentElement.clientWidth; if(rect.right>vw-10){ panel.style.left='auto'; panel.style.right='0'; }}
 
 /* ===== elements/state ===== */
-const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),viewToggleBtn:document.getElementById('viewToggleBtn'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),clearMonthBtn:document.getElementById('clearMonth'),status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),charts:document.getElementById('chartsSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),barStore:document.getElementById('barStore'),barLo:document.getElementById('barLo'),barCat:document.getElementById('barCat'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},start:document.getElementById('startDate'),end:document.getElementById('endDate'),search:document.getElementById('searchFilter')};
-const state={ rows:[], columns:{}, charts:{store:null, lo:null, cat:null}, monthSel:new Set(), monthOptions:[], snapshot:{}, viewMode:'pivot', hasData:false };
+const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),clearMonthBtn:document.getElementById('clearMonth'),status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},start:document.getElementById('startDate'),end:document.getElementById('endDate'),search:document.getElementById('searchFilter')};
+const state={ rows:[], columns:{}, monthSel:new Set(), monthOptions:[], snapshot:{}, hasData:false };
 const DEFAULT_WORKBOOK='Products Search Term.xlsx';
 
 
@@ -357,10 +334,6 @@ function boot(){
   }
   if(el.fileInput) el.fileInput.addEventListener('change', handleLocalFile);
   if(el.dlCsv) el.dlCsv.addEventListener('click', onDownloadCsv);
-  if(el.viewToggleBtn){
-    el.viewToggleBtn.addEventListener('click', toggleViewMode);
-  }
-
   el.openFiltersBtn.addEventListener('click', openFiltersModal);
   el.closeFiltersBtn.addEventListener('click', closeFiltersCancel);
   el.cancelFiltersBtn.addEventListener('click', closeFiltersCancel);
@@ -392,101 +365,21 @@ function setHasData(has){
   if(has){
     if(el.topLine) el.topLine.style.display='flex';
     if(el.kpis) el.kpis.hidden=false;
+    if(el.pivot?.section) el.pivot.section.hidden=false;
     if(el.openFiltersBtn) el.openFiltersBtn.style.display='inline-flex';
-    if(el.viewToggleBtn){
-      el.viewToggleBtn.style.display='inline-flex';
-      el.viewToggleBtn.hidden=true;
-      el.viewToggleBtn.textContent = 'Show Charts';
-      el.viewToggleBtn.setAttribute('aria-pressed','false');
-    }
     if(el.dlCsv) el.dlCsv.disabled=false;
     if(el.monthsWrap) el.monthsWrap.hidden = state.monthOptions.length===0;
     if(el.tipPill) el.tipPill.hidden=true;
   }else{
     if(el.topLine) el.topLine.style.display='none';
     if(el.kpis) el.kpis.hidden=true;
-    if(el.charts) el.charts.hidden=true;
     if(el.pivot?.section) el.pivot.section.hidden=true;
     if(el.openFiltersBtn) el.openFiltersBtn.style.display='none';
-    if(el.viewToggleBtn){
-      el.viewToggleBtn.style.display='none';
-      el.viewToggleBtn.hidden=true;
-      el.viewToggleBtn.setAttribute('aria-pressed','false');
-      el.viewToggleBtn.textContent = 'Show Charts';
-    }
     if(el.dlCsv) el.dlCsv.disabled=true;
     if(el.monthsWrap) el.monthsWrap.hidden=true;
     if(el.tipPill) el.tipPill.hidden=true;
     resetKpis();
   }
-}
-
-function setViewMode(mode){
-  const hasPivot = !!state.pivotHasContent;
-  const hasCharts = !!state.chartHasContent;
-  let desired = mode==='charts' ? 'charts' : 'pivot';
-  if(desired==='charts' && !hasCharts && hasPivot) desired='pivot';
-  if(desired==='pivot' && !hasPivot && hasCharts) desired='charts';
-  if(!hasPivot && !hasCharts) desired='pivot';
-
-  state.viewMode = desired;
-
-  const showCharts = desired==='charts' && hasCharts;
-  const showPivot = desired==='pivot' && hasPivot;
-
-  if(el.charts) el.charts.hidden = !showCharts;
-  if(el.pivot?.section) el.pivot.section.hidden = !showPivot;
-
-  if(el.viewToggleBtn){
-    const bothAvailable = hasPivot && hasCharts;
-    el.viewToggleBtn.hidden = !bothAvailable;
-    if(bothAvailable){
-      const nextMode = showCharts ? 'pivot' : 'charts';
-      el.viewToggleBtn.textContent = nextMode==='charts' ? 'Show Charts' : 'Show Pivot';
-      el.viewToggleBtn.setAttribute('aria-pressed', showCharts ? 'true' : 'false');
-      el.viewToggleBtn.setAttribute('aria-label', showCharts ? 'Switch to pivot view' : 'Switch to chart view');
-    }else{
-      el.viewToggleBtn.setAttribute('aria-pressed','false');
-      el.viewToggleBtn.textContent = 'Show Charts';
-    }
-  }
-
-  if(showCharts){
-    requestAnimationFrame(()=>{
-      Object.values(state.charts).forEach(chart=>{ if(chart){ chart.resize(); chart.update('none'); } });
-    });
-  }
-}
-function toggleViewMode(){
-  if(state.viewMode==='pivot' && state.chartHasContent){
-    setViewMode('charts');
-  }else if(state.viewMode==='charts' && state.pivotHasContent){
-    setViewMode('pivot');
-  }
-}
-
-function applyViewMode(pivotAvailable, chartsAvailable){
-  state.pivotHasContent = !!pivotAvailable;
-  state.chartHasContent = !!chartsAvailable;
-
-  if(!state.pivotHasContent && !state.chartHasContent){
-    if(el.viewToggleBtn){
-      el.viewToggleBtn.hidden = true;
-      el.viewToggleBtn.setAttribute('aria-pressed','false');
-      el.viewToggleBtn.textContent = 'Show Charts';
-    }
-    if(el.charts) el.charts.hidden = true;
-    if(el.pivot?.section) el.pivot.section.hidden = true;
-    return;
-  }
-
-  if(state.viewMode==='charts' && !state.chartHasContent && state.pivotHasContent){
-    state.viewMode='pivot';
-  }else if(state.viewMode!=='charts' && !state.pivotHasContent && state.chartHasContent){
-    state.viewMode='charts';
-  }
-
-  setViewMode(state.viewMode);
 }
 
 /* ===== Excel parsing (headers row 2, data from row 3) ===== */
@@ -515,15 +408,20 @@ async function handleLocalFile(e){
 async function loadWorkbookBuffer(buf){
   await parseExcel(buf);
   setHasData(true);
-  setViewMode(state.viewMode);
 }
 async function attemptDefaultWorkbook(){
   const file=DEFAULT_WORKBOOK && DEFAULT_WORKBOOK.trim();
   if(!file || state.hasData) return;
   try{
     showLoading(true);
-    const response=await fetch(encodeURI(file),{cache:'no-store'});
-    if(!response.ok) throw new Error('Default workbook not found');
+    let targetUrl;
+    try{
+      targetUrl=new URL(file, document.baseURI).href;
+    }catch(_){
+      targetUrl=encodeURI(file);
+    }
+    const response=await fetch(targetUrl,{cache:'no-store'});
+    if(!response.ok && response.status!==0) throw new Error('Default workbook not found');
     if(state.hasData) return;
     const buf=await response.arrayBuffer();
     if(state.hasData) return;
@@ -591,15 +489,6 @@ async function parseExcel(buf){
     if(Object.values(o).some(val => (val!=='' && val!=null))) rows.push(o);
   }
   state.rows=rows;
-  state.viewMode='pivot';
-  state.pivotHasContent=false;
-  state.chartHasContent=false;
-  if(el.viewToggleBtn){
-    el.viewToggleBtn.hidden=true;
-    el.viewToggleBtn.textContent = 'Show Charts';
-    el.viewToggleBtn.setAttribute('aria-pressed','false');
-  }
-
   buildMonths(); initFilters(); renderAll();
 }
 
@@ -808,103 +697,6 @@ function renderKPIs(x){
   el.kpi.avgcpc.textContent  = isFinite(x.avgcpc) ? fmt.money(x.avgcpc) : '—';
 }
 
-/* ===== ACOS label plugin (above dots) ===== */
-const acosLabelPlugin={ id:'acosLbl', afterDatasetsDraw(chart){
-  const dsIndex = chart.data.datasets.findIndex(d=>d.type==='scatter' && d.label==='ACOS');
-  if(dsIndex<0) return;
-  const ds = chart.data.datasets[dsIndex];
-  const meta=chart.getDatasetMeta(dsIndex);
-  const ctx=chart.ctx; ctx.save();
-  ctx.font='700 11px system-ui,-apple-system,Segoe UI,Roboto,Arial';
-  ctx.fillStyle=getComputedStyle(document.body).getPropertyValue('--text').trim()||'#fff';
-  meta.data.forEach((pt,i)=>{
-    const raw = ds.data[i];
-    if(!raw && raw!==0) return;
-    const p=pt.getProps(['x','y'],true);
-    const ratio = (typeof raw==='number')? raw : (chart.options.indexAxis==='y' ? raw.x : raw.y);
-    const label = (ratio*100).toFixed(0)+'%';
-    ctx.textAlign='center';
-    ctx.fillText(label, p.x, p.y-8);
-  });
-  ctx.restore();
-}};
-Chart.register(acosLabelPlugin);
-
-const barValueLabelPlugin={
-  id:'barValueLbl',
-  afterDatasetsDraw(chart){
-    const axis = chart.options.indexAxis || 'x';
-    const ctx = chart.ctx;
-    const color = getComputedStyle(document.body).getPropertyValue('--text').trim()||'#fff';
-    ctx.save();
-    ctx.font='700 11px system-ui,-apple-system,Segoe UI,Roboto,Arial';
-    ctx.fillStyle=color;
-    chart.data.datasets.forEach((dataset, datasetIndex)=>{
-      const type = dataset.type || chart.config.type;
-      if(type!=='bar') return;
-      const meta = chart.getDatasetMeta(datasetIndex);
-      if(meta.hidden) return;
-      meta.data.forEach((element,index)=>{
-        const parsed = meta._parsed?.[index];
-        let value;
-        if(parsed!=null){
-          if(typeof parsed==='object') value = axis==='y' ? parsed.x ?? parsed.y : parsed.y ?? parsed.x;
-          else value = parsed;
-        }else{
-          const raw = dataset.data[index];
-          if(raw==null) return;
-          if(typeof raw==='object'){ value = axis==='y' ? raw.x ?? raw.y ?? raw.value ?? raw.v : raw.y ?? raw.x ?? raw.value ?? raw.v; }
-          else value = raw;
-        }
-        if(!isFinite(value)) return;
-        const label = fmt.num0(value);
-        const props = element.getProps(['x','y','base'],true);
-        if(axis==='y'){
-          const isPositive = value>=0;
-          const baseX = props.base ?? props.x;
-          const anchor = isPositive ? Math.max(props.x, baseX) : Math.min(props.x, baseX);
-          const offset = 6;
-          const side = datasetIndex>0 ? 1 : -1;
-          ctx.textAlign = side>0?'left':'right';
-          ctx.textBaseline='middle';
-          const targetX = anchor + side*offset*(isPositive?1:-1);
-          ctx.fillText(label, targetX, props.y);
-        }else{
-          const isPositive = value>=0;
-          const baseY = props.base ?? props.y;
-          const anchorY = isPositive ? Math.min(props.y, baseY) : Math.max(props.y, baseY);
-          const offsetY = 6;
-          const side = datasetIndex>0 ? 1 : -1;
-          ctx.textAlign = side>0?'left':'right';
-          ctx.textBaseline = isPositive ? 'bottom' : 'top';
-          const targetY = anchorY + (isPositive ? -offsetY : offsetY);
-          const targetX = props.x + side*6;
-          ctx.fillText(label, targetX, targetY);
-        }
-      });
-    });
-    ctx.restore();
-  }
-};
-Chart.register(barValueLabelPlugin);
-
-/* ===== build charts ===== */
-function barSizing(count, orientation){
-  const n = Math.max(1, count);
-  if(orientation==='horizontal'){
-    if(n<=4) return {category:0.6, bar:0.65, max:38};
-    if(n<=8) return {category:0.68, bar:0.72, max:32};
-    if(n<=14) return {category:0.76, bar:0.8, max:26};
-    if(n<=20) return {category:0.82, bar:0.86, max:22};
-    return {category:0.88, bar:0.9, max:18};
-  }
-  if(n<=4) return {category:0.55, bar:0.7, max:52};
-  if(n<=8) return {category:0.66, bar:0.78, max:42};
-  if(n<=12) return {category:0.74, bar:0.84, max:32};
-  if(n<=18) return {category:0.82, bar:0.9, max:26};
-  return {category:0.88, bar:0.94, max:20};
-}
-
 function buildAgg(rows, keyCol, spendKey, salesKey){
   const agg=new Map();
   for(const r of rows){
@@ -916,101 +708,6 @@ function buildAgg(rows, keyCol, spendKey, salesKey){
   const spend=labels.map(k=>agg.get(k).sp);
   const sales=labels.map(k=>agg.get(k).sa);
   return {labels, spend, sales};
-}
-
-/* Horizontal (Store) – overlay bars; ACOS on top axis as scatter */
-function configHorizontal(labels, spend, sales){
-  const sizing = barSizing(labels.length,'horizontal');
-  const spendBarPct = Math.max(0.4, sizing.bar*0.82);
-  const acosPoints = labels.map((lab,i)=>({x: sales[i]>0?spend[i]/sales[i]:0, y: lab}));
-  return {
-    type:'bar',
-    data:{
-      labels,
-      datasets:[
-        {label:'Sales', order:1, parsing:false, yAxisID:'y',
-         data: labels.map((_,i)=>({x:sales[i], y:labels[i]})),
-         backgroundColor:'rgba(16,185,129,0.45)', borderWidth:0,
-         grouped:false, categoryPercentage:sizing.category, barPercentage:sizing.bar, borderRadius:0,
-         maxBarThickness:sizing.max},
-        {label:'Spend', order:2, parsing:false, yAxisID:'y',
-         data: labels.map((_,i)=>({x:spend[i], y:labels[i]})),
-         backgroundColor:'rgba(37,99,235,0.95)', borderColor:'#1e40af', borderWidth:1.5, borderSkipped:false,
-         grouped:false, categoryPercentage:sizing.category, barPercentage:spendBarPct, borderRadius:0,
-         maxBarThickness:Math.max(12, sizing.max*0.92)},
-        {type:'scatter', label:'ACOS', order:99, parsing:false, xAxisID:'x2', yAxisID:'y',
-         data: acosPoints, backgroundColor:'#ef4444', borderColor:'#ef4444',
-         pointRadius:3, pointHoverRadius:4, showLine:false, clip:false}
-      ]
-    },
-    options:{
-      indexAxis:'y',
-      maintainAspectRatio:false,
-      interaction:{mode:'index',axis:'y',intersect:false},
-      plugins:{
-        legend:{display:false},
-        tooltip:{displayColors:false,callbacks:{
-          title:(it)=>it[0]?.label||'',
-          label:(ctx)=>{
-            if(ctx.dataset.type==='scatter'){ return ` ACOS: ${(ctx.raw.x*100).toFixed(0)}%`; }
-            return ` ${ctx.dataset.label}: ${fmt.money(ctx.raw.x)}`;
-          }
-        }}
-      },
-      scales:{
-        x:{ position:'bottom', ticks:{ callback:(v)=>fmt.compact(v) }, grid:{drawBorder:false} },
-        x2:{ position:'top', min:0, suggestedMax: Math.max(0.1, Math.ceil(((Math.max(...acosPoints.map(p=>p.x))||0)*100+10))/100),
-             ticks:{display:false}, grid:{drawOnChartArea:false}, border:{display:false} },
-        y:{ type:'category', labels, grid:{display:false} }
-      }
-    }
-  };
-}
-
-/* Vertical (LO, Category) – overlay bars; ACOS on right y2 as scatter */
-function configVertical(labels, spend, sales){
-  const sizing = barSizing(labels.length,'vertical');
-  const spendBarPct = Math.max(0.42, sizing.bar*0.82);
-  const acosPoints = labels.map((lab,i)=>({x: lab, y: sales[i]>0?spend[i]/sales[i]:0}));
-  return {
-    type:'bar',
-    data:{
-      labels,
-      datasets:[
-        {label:'Sales', order:1, yAxisID:'y',
-         data: sales, backgroundColor:'rgba(16,185,129,0.45)', borderWidth:0,
-         grouped:false, categoryPercentage:sizing.category, barPercentage:sizing.bar, borderRadius:0,
-         maxBarThickness:sizing.max},
-        {label:'Spend', order:2, yAxisID:'y',
-         data: spend, backgroundColor:'rgba(37,99,235,0.95)', borderColor:'#1e40af', borderWidth:1.5, borderSkipped:false,
-         grouped:false, categoryPercentage:sizing.category, barPercentage:spendBarPct, borderRadius:0,
-         maxBarThickness:Math.max(14, sizing.max*0.92)},
-        {type:'scatter', label:'ACOS', order:99, parsing:false, xAxisID:'x', yAxisID:'y2',
-         data: acosPoints, backgroundColor:'#ef4444', borderColor:'#ef4444',
-         pointRadius:3, pointHoverRadius:4, showLine:false, clip:false}
-      ]
-    },
-    options:{
-      maintainAspectRatio:false,
-      interaction:{mode:'index',axis:'x',intersect:false},
-      plugins:{
-        legend:{display:false},
-        tooltip:{displayColors:false,callbacks:{
-          title:(it)=>it[0]?.label||'',
-          label:(ctx)=>{
-            if(ctx.dataset.type==='scatter'){ return ` ACOS: ${(ctx.raw.y*100).toFixed(0)}%`; }
-            return ` ${ctx.dataset.label}: ${fmt.money(ctx.parsed.y)}`;
-          }
-        }}
-      },
-      scales:{
-        x:{ grid:{display:false}, title:{display:false} },
-        y:{ position:'left', ticks:{ callback:(v)=>fmt.compact(v) }, grid:{drawBorder:false} },
-        y2:{ position:'right', min:0, suggestedMax: Math.max(0.1, Math.ceil(((Math.max(...acosPoints.map(p=>p.y))||0)*100+10))/100),
-             ticks:{display:false}, grid:{drawOnChartArea:false}, border:{display:false} }
-      }
-    }
-  };
 }
 
 function renderPivotCard(target, columnLabel, agg, hasColumn){
@@ -1055,29 +752,8 @@ function renderPivotCard(target, columnLabel, agg, hasColumn){
   const totalAcos = totalSales>0 ? totalSpend/totalSales : NaN;
   const totalRow = `<tr class="pivot-total"><th scope="row">Total</th>${buildMoneyCell(totalSpend)}${buildMoneyCell(totalSales)}${buildAcosCell(totalAcos,true)}</tr>`;
 
-  target.table.innerHTML = head + `<tbody>${bodyRows}${totalRow}</tbody>`;
+  target.table.innerHTML = head + `<tbody>${bodyRows}</tbody><tfoot>${totalRow}</tfoot>`;
   return true;
-}
-
-/* Top charts equal height (slightly larger & equal for Store and LO) */
-function setTopHeights(storeCount, loCount){
-  const maxItems = Math.max(storeCount||0, loCount||0);
-  const per = maxItems<=4 ? 40 : maxItems<=10 ? 30 : 22;
-  const base = maxItems<=4 ? 140 : 110;
-  const minH = 180, maxH = 480;
-  const h = Math.max(minH, Math.min(maxH, base + Math.max(0, maxItems-1)*per));
-
-  document.getElementById('chartLeft').style.height  = h+'px';
-  document.getElementById('chartRight').style.height = h+'px';
-  /* category chart height handled separately */
-}
-
-function setCategoryHeight(catCount){
-  const base = catCount<=3 ? 220 : 260;
-  const per = catCount<=6 ? 28 : catCount<=12 ? 22 : 18;
-  const minH = 260, maxH = 600;
-  const h = Math.max(minH, Math.min(maxH, base + Math.max(0, catCount-1)*per));
-  document.getElementById('chartCat').style.height = h+'px';
 }
 
 /* ===== render & CSV ===== */
@@ -1090,16 +766,13 @@ function renderAll(){
   const catKey   = state.columns.category ? normalize(state.columns.category.name) : null;
   const spendKey = state.columns.spend ? normalize(state.columns.spend.name) : null;
   const salesKey = state.columns.revenue ? normalize(state.columns.revenue.name) : null;
+
   if(!spendKey || !salesKey){
-    ['store','lo','cat'].forEach(name=>{
-      if(state.charts[name]){ state.charts[name].destroy(); state.charts[name]=null; }
-    });
-    renderPivotCard(el.pivot.store, state.columns.store?.name || 'Store', null, !!storeKey);
-    renderPivotCard(el.pivot.lo, state.columns.lo?.name || 'LO', null, !!loKey);
-    renderPivotCard(el.pivot.cat, state.columns.category?.name || 'Category', null, !!catKey);
-    state.pivotHasContent=false;
-    state.chartHasContent=false;
-    applyViewMode(false, false);
+    const pivotStoreVisible = renderPivotCard(el.pivot.store, state.columns.store?.name || 'Store', null, !!storeKey);
+    const pivotLoVisible    = renderPivotCard(el.pivot.lo, state.columns.lo?.name || 'LO', null, !!loKey);
+    const pivotCatVisible   = renderPivotCard(el.pivot.cat, state.columns.category?.name || 'Category', null, !!catKey);
+    const anyPivot = pivotStoreVisible || pivotLoVisible || pivotCatVisible;
+    if(el.pivot?.section) el.pivot.section.hidden = !anyPivot;
     return;
   }
 
@@ -1107,45 +780,12 @@ function renderAll(){
   const loAgg    = loKey    ? buildAgg(rows, loKey, spendKey, salesKey)    : null;
   const catAgg   = catKey   ? buildAgg(rows, catKey, spendKey, salesKey)   : null;
 
-
-  const storeCount = storeAgg ? storeAgg.labels.length : 0;
-  const loCount    = loAgg    ? loAgg.labels.length    : 0;
-
-  if(storeAgg){
-    if(state.charts.store){ state.charts.store.destroy(); state.charts.store=null; }
-    state.charts.store = new Chart(el.barStore.getContext('2d'), configHorizontal(storeAgg.labels, storeAgg.spend, storeAgg.sales));
-  }else if(state.charts.store){
-    state.charts.store.destroy();
-    state.charts.store=null;
-
-  }
-
-  if(loAgg){
-    if(state.charts.lo){ state.charts.lo.destroy(); state.charts.lo=null; }
-    state.charts.lo = new Chart(el.barLo.getContext('2d'), configVertical(loAgg.labels, loAgg.spend, loAgg.sales));
-  }else if(state.charts.lo){
-    state.charts.lo.destroy();
-    state.charts.lo=null;
-  }
-
-  if(catAgg){
-    if(state.charts.cat){ state.charts.cat.destroy(); state.charts.cat=null; }
-    setCategoryHeight(catAgg.labels.length);
-    state.charts.cat = new Chart(el.barCat.getContext('2d'), configVertical(catAgg.labels, catAgg.spend, catAgg.sales));
-  }else{
-    if(state.charts.cat){ state.charts.cat.destroy(); state.charts.cat=null; }
-    setCategoryHeight(0);
-  }
-
-  setTopHeights(storeCount, loCount);
-
   const pivotStoreVisible = renderPivotCard(el.pivot.store, state.columns.store?.name || 'Store', storeAgg, !!storeKey);
   const pivotLoVisible    = renderPivotCard(el.pivot.lo, state.columns.lo?.name || 'LO', loAgg, !!loKey);
   const pivotCatVisible   = renderPivotCard(el.pivot.cat, state.columns.category?.name || 'Category', catAgg, !!catKey);
-  const pivotAny = pivotStoreVisible || pivotLoVisible || pivotCatVisible;
-  const chartsAvailable = [storeAgg, loAgg, catAgg].some(agg=>agg && agg.labels && agg.labels.length);
+  const anyPivot = pivotStoreVisible || pivotLoVisible || pivotCatVisible;
 
-  applyViewMode(pivotAny, chartsAvailable);
+  if(el.pivot?.section) el.pivot.section.hidden = !anyPivot;
 }
 
 function onDownloadCsv(){


### PR DESCRIPTION
## Summary
- remove chart dependencies and the view toggle so the dashboard focuses on the pivot tables
- keep pivot data legible with sticky headers/footers, matching alignment, and updated grand-total styling
- make the default workbook fetch more robust so the bundled spreadsheet loads automatically

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce5fc1558c8329a691b038cb4f7a35