### PR TITLE
Fix pivot totals overflow and hide tip once data loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@ body:not(.has-data) #pivotSection{display:none !important}
 
 /* Topline */
 .topline{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:8px clamp(14px,3vw,28px);flex-wrap:wrap}
+body.has-data #tipPill{display:none !important}
 .topline-controls{display:flex;align-items:center;gap:10px;flex-wrap:wrap;justify-content:flex-end}
 .pill{display:inline-flex;align-items:center;gap:8px;padding:8px 12px;background:var(--chip);border:1px solid var(--border);border-radius:999px;color:var(--muted)}
 .months-wrap{display:flex;align-items:center;gap:6px}
@@ -90,7 +91,7 @@ body:not(.has-data) #pivotSection{display:none !important}
 .chart-title{font-weight:700;margin-bottom:8px;color:var(--muted)}
 .pivot-card{margin:0;width:100%}
 .pivot-card+.pivot-card{margin-top:0}
-.pivot-body{margin-top:10px;overflow:auto;max-height:clamp(360px,55vh,520px);position:relative;border-radius:10px;padding-bottom:4px;background:var(--panel)}
+.pivot-body{margin-top:10px;overflow:auto;max-height:clamp(360px,55vh,520px);position:relative;border-radius:10px;padding-bottom:0;background:var(--panel);box-shadow:inset 0 1px 0 var(--border-strong),inset 0 -1px 0 var(--border-strong),inset 0 -3px 0 var(--border-strong)}
 .pivot-table{width:100%;border-collapse:collapse;min-width:320px;font-variant-numeric:tabular-nums}
 .pivot-table thead th{padding:10px 12px;border-bottom:2px solid var(--border-strong);font-weight:700;color:var(--muted);font-size:12.5px;letter-spacing:.3px;text-transform:uppercase;position:sticky;top:0;background:var(--panel);z-index:3;text-align:right}
 .pivot-table thead th:first-child{text-align:left}
@@ -377,7 +378,7 @@ function setHasData(has){
     if(el.openFiltersBtn) el.openFiltersBtn.style.display='none';
     if(el.dlCsv) el.dlCsv.disabled=true;
     if(el.monthsWrap) el.monthsWrap.hidden=true;
-    if(el.tipPill) el.tipPill.hidden=true;
+    if(el.tipPill) el.tipPill.hidden=false;
     resetKpis();
   }
 }


### PR DESCRIPTION
## Summary
- hide the top banner tip whenever workbook data is available so the "No Excel" message never shows with data
- remove extra scroll padding and add inset lines so the pivot header and total separators remain visible outside the scroll area

## Testing
- Not run (static page)

------
https://chatgpt.com/codex/tasks/task_e_68ce67407c08832980f9b3f539685c01