### PR TITLE
Update pivot layout and fix dropdown search filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,18 @@ body.has-data #tipPill{display:none !important}
 
 /* Pivot table */
 .pivot{padding:6px clamp(14px,3vw,26px) 20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--chartsGap);align-items:start}
+.pivot[data-mode="overall"] #pivotStoreCard,
+.pivot[data-mode="overall"] #pivotLoCard,
+.pivot[data-mode="overall"] #pivotCatCard,
+.pivot[data-mode="overall"] #pivotCustTypeCard,
+.pivot[data-mode="overall"] #pivotPlacementCard{grid-column:auto}
+@media(min-width:960px){
+  .pivot[data-mode="overall"]{grid-template-columns:repeat(12,minmax(0,1fr))}
+  .pivot[data-mode="overall"] .pivot-card{grid-column:span 12}
+  .pivot[data-mode="overall"] #pivotStoreCard,.pivot[data-mode="overall"] #pivotLoCard{grid-column:1 / span 4}
+  .pivot[data-mode="overall"] #pivotCatCard{grid-column:5 / span 4}
+  .pivot[data-mode="overall"] #pivotCustTypeCard,.pivot[data-mode="overall"] #pivotPlacementCard{grid-column:9 / span 4}
+}
 .chart-card{position:relative;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px 12px 10px;box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:hidden}
 .chart-title{font-weight:700;margin-bottom:8px;color:var(--muted)}
 .pivot-card{margin:0;width:100%}
@@ -167,6 +179,9 @@ body.has-data #tipPill{display:none !important}
 .dd-text{white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:30ch}
 .dd-only{border:1px solid var(--border);background:var(--chip);color:var(--muted);border-radius:8px;padding:4px 8px;cursor:pointer}
 .dd-count{text-align:right;color:var(--muted);font-variant-numeric:tabular-nums}
+.dd-empty{padding:12px;text-align:center;color:var(--muted);font-weight:600;display:none}
+.dd.no-results .dd-list{display:none}
+.dd.no-results .dd-empty{display:block}
 
 /* responsive */
 @media (max-width:980px){.kpis{grid-template-columns:repeat(4,1fr)}}
@@ -246,6 +261,18 @@ body.has-data #tipPill{display:none !important}
       <table id="pivotTableCat" class="pivot-table"></table>
     </div>
   </div>
+  <div class="chart-card pivot-card" id="pivotCustTypeCard">
+    <div class="chart-title">Customer Search Term - TYPE Performance Pivot</div>
+    <div class="pivot-body">
+      <table id="pivotTableCustType" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card" id="pivotPlacementCard">
+    <div class="chart-title">Placement Performance Pivot</div>
+    <div class="pivot-body">
+      <table id="pivotTablePlacement" class="pivot-table"></table>
+    </div>
+  </div>
 </section>
 
 </main>
@@ -262,8 +289,8 @@ body.has-data #tipPill{display:none !important}
       <div class="filter" data-col-wrapper="category"><label data-col-label="category" data-default="Category">Category</label><div id="categoryMS" class="dd"></div></div>
       <div class="filter" data-col-wrapper="lo"><label data-col-label="lo" data-default="Store">Store</label><div id="loMS" class="dd"></div></div>
       <div class="filter" data-col-wrapper="ttype"><label data-col-label="ttype" data-default="Targeting Type">Targeting Type</label><div id="ttypeMS" class="dd"></div></div>
-      <div class="filter" data-col-wrapper="tsub"><label data-col-label="tsub" data-default="Targeting SubType">Targeting SubType</label><div id="tsubMS" class="dd"></div></div>
-      <div class="filter" data-col-wrapper="tsub2"><label data-col-label="tsub2" data-default="Targeting SubType2">Targeting SubType2</label><div id="tsub2MS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="tsub"><label data-col-label="tsub" data-default="Targeting Sub Type">Targeting Sub Type</label><div id="tsubMS" class="dd"></div></div>
+      <div class="filter" data-col-wrapper="tsub2"><label data-col-label="tsub2" data-default="Targeting Sub Type2">Targeting Sub Type2</label><div id="tsub2MS" class="dd"></div></div>
       <div class="filter grow" data-col-wrapper="campaign"><label data-col-label="campaign" data-default="Campaign Name">Campaign Name</label><div id="campaignMS" class="dd"></div></div>
       <div class="filter grow" data-col-wrapper="portfolio"><label data-col-label="portfolio" data-default="Portfolio Name">Portfolio Name</label><div id="portfolioMS" class="dd"></div></div>
 
@@ -309,7 +336,7 @@ function parseNumber(v){ if(v==null || v==="") return 0; if(typeof v==='number' 
 function clampPanelRight(panel){ panel.style.left='0'; panel.style.right='auto'; const rect=panel.getBoundingClientRect(), vw=document.documentElement.clientWidth; if(rect.right>vw-10){ panel.style.left='auto'; panel.style.right='0'; }}
 
 /* ===== elements/state ===== */
-const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),clearMonthBtn:document.getElementById('clearMonth'),tabs:{bar:document.getElementById('pivotTabsBar'),list:document.getElementById('pivotTabs')},status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},start:document.getElementById('startDate'),end:document.getElementById('endDate'),search:document.getElementById('searchFilter')};
+const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),clearMonthBtn:document.getElementById('clearMonth'),tabs:{bar:document.getElementById('pivotTabsBar'),list:document.getElementById('pivotTabs')},status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')},custType:{card:document.getElementById('pivotCustTypeCard'),table:document.getElementById('pivotTableCustType')},placement:{card:document.getElementById('pivotPlacementCard'),table:document.getElementById('pivotTablePlacement')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},start:document.getElementById('startDate'),end:document.getElementById('endDate'),search:document.getElementById('searchFilter')};
 const state={ rows:[], columns:{}, monthSel:new Set(), monthOptions:[], monthDirty:false, snapshot:{}, hasData:false, activeTab:'overview' };
 if(el.tabs?.list){ el.tabs.buttons = Array.from(el.tabs.list.querySelectorAll('[data-tab]')); }
 const PIVOT_CONFIG={
@@ -320,8 +347,10 @@ const PIVOT_CONFIG={
   ],
   overall:[
     {slot:'store', column:'ttype', fallback:'Targeting Type'},
-    {slot:'lo', column:'tsub', fallback:'Targeting SubType'},
-    {slot:'cat', column:'tsub2', fallback:'Targeting SubType2'}
+    {slot:'lo', column:'tsub', fallback:'Targeting Sub Type'},
+    {slot:'cat', column:'tsub2', fallback:'Targeting Sub Type2'},
+    {slot:'custType', column:'customerType', fallback:'Customer Search Term - TYPE'},
+    {slot:'placement', column:'placement', fallback:'Placement'}
   ]
 };
 const DEFAULT_WORKBOOK='Products Search Term.xlsx';
@@ -547,6 +576,8 @@ async function parseExcel(buf){
     ttype:      findIndexByTokens(headers,['targetingtype','adtype','type']),
     tsub:       findIndexByTokens(headers,['targetingsubtype','matchtype','subtype']),
     tsub2:      findIndexByTokens(headers,['subtype2','matchtype2']),
+    customerType:findIndexByTokens(headers,['customersearchtermtype','searchtermtype']),
+    placement:  findIndexByTokens(headers,['placement','placements']),
     campaign:   findIndexByTokens(headers,['campaignname','campaign']),
     portfolio:  findIndexByTokens(headers,['portfolioname','portfolio']),
   };
@@ -636,25 +667,19 @@ function ddBuild(root){
         <div class="rc">Record Count</div>
       </div>
       <div class="dd-list"></div>
+      <div class="dd-empty">No results</div>
     </div>`;
   const control=root.querySelector('.dd-control');
   control.addEventListener('click', ()=>{
     const willOpen=!root.classList.contains('open');
     document.querySelectorAll('.dd.open').forEach(n=>n.classList.remove('open'));
     root.classList.toggle('open', willOpen);
-    if(willOpen){ clampPanelRight(root.querySelector('.dd-panel')); root.querySelector('.dd-search').focus(); }
+    if(willOpen){ clampPanelRight(root.querySelector('.dd-panel')); root.querySelector('.dd-search').focus(); ddApplySearchFilter(root); }
   });
   root.querySelector('.dd-panel').addEventListener('click', (e)=> e.stopPropagation());
   const searchEl=root.querySelector('.dd-search');
-  const doFilter=()=>{
-    const q = searchEl.value.trim().toLowerCase();
-    root.querySelectorAll('.dd-item').forEach(item=>{
-      const txt = item.querySelector('.dd-text').textContent.toLowerCase();
-      item.hidden = q && !txt.includes(q);
-    });
-    ddSyncSelectAll(root);
-  };
-  searchEl.addEventListener('input', doFilter);
+  searchEl.addEventListener('input', ()=>ddApplySearchFilter(root));
+  searchEl.addEventListener('search', ()=>ddApplySearchFilter(root));
   root.querySelector('.dd-select-all').addEventListener('change', (e)=>{
     const on = e.target.checked;
     const vis = root.querySelectorAll('.dd-item:not([hidden]) input[type=checkbox]');
@@ -685,7 +710,8 @@ function ddSetOptions(root, items, keepSel=true){
   list.querySelectorAll('input[type=checkbox]').forEach(cb=>{
     cb.addEventListener('change', ()=>{ ddUpdateSummary(root); ddSyncSelectAll(root); });
   });
-  ddUpdateSummary(root); ddSyncSelectAll(root);
+  ddApplySearchFilter(root);
+  ddUpdateSummary(root);
 }
 function ddGetSelected(root){ return Array.from(root.querySelectorAll('.dd-list input[type=checkbox]:checked')).map(cb=>cb.value); }
 function ddUpdateSummary(root){
@@ -695,6 +721,21 @@ function ddUpdateSummary(root){
 function ddSyncSelectAll(root){
   const vis=Array.from(root.querySelectorAll('.dd-item:not([hidden]) input[type=checkbox]'));
   root.querySelector('.dd-select-all').checked = (vis.length && vis.every(cb=>cb.checked));
+}
+function ddApplySearchFilter(root){
+  if(!root) return;
+  const searchEl=root.querySelector('.dd-search');
+  const q=searchEl ? searchEl.value.trim().toLowerCase() : '';
+  let matches=0;
+  root.querySelectorAll('.dd-item').forEach(item=>{
+    const text=item.querySelector('.dd-text');
+    const txt=text?text.textContent.toLowerCase():'';
+    const show=!q || txt.includes(q);
+    item.hidden=!show;
+    if(show) matches++;
+  });
+  root.classList.toggle('no-results', matches===0);
+  ddSyncSelectAll(root);
 }
 
 function syncFilterLabels(){
@@ -913,9 +954,12 @@ function renderAll(){
   const spendKey = state.columns.spend ? normalize(state.columns.spend.name) : null;
   const salesKey = state.columns.revenue ? normalize(state.columns.revenue.name) : null;
   const config=getPivotConfig();
+  if(el.pivot?.section) el.pivot.section.dataset.mode = state.activeTab || 'overview';
+  const usedSlots=new Set();
   const visibilities=config.map(({slot,column,fallback})=>{
     const target=el.pivot?.[slot];
     if(!target) return false;
+    usedSlots.add(slot);
     const columnDef=state.columns[column];
     const columnName=columnDef?.name || fallback;
     const columnKey=columnDef ? normalize(columnDef.name) : null;
@@ -923,6 +967,19 @@ function renderAll(){
     const agg = hasMetrics ? buildAgg(rows, columnKey, spendKey, salesKey) : null;
     return renderPivotCard(target, columnName, agg, !!columnKey);
   });
+  if(el.pivot){
+    Object.entries(el.pivot).forEach(([slot,target])=>{
+      if(slot==='section') return;
+      if(!usedSlots.has(slot) && target?.card){
+        target.card.hidden=true;
+        if(target.table){
+          target.table.innerHTML='';
+          target.table.classList.remove('has-grand-total');
+          updatePivotFootSpace(target.table);
+        }
+      }
+    });
+  }
   const anyPivot=visibilities.some(Boolean);
   if(el.pivot?.section) el.pivot.section.hidden = !anyPivot;
 }


### PR DESCRIPTION
## Summary
- enable dropdown search inputs to filter option lists and display a helpful empty state
- add Customer Search Term - TYPE and Placement pivot cards while rearranging the overall pivot layout to match the requested order
- detect the new workbook columns and refresh fallback labels for the updated pivots

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce8750c0088329975b7f505179eeb2