### PR TITLE
Arrange overall pivots into two columns

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,11 +100,11 @@ body.has-data #tipPill{display:none !important}
 @media(min-width:960px){
   .pivot[data-mode="overall"]{grid-template-columns:repeat(12,minmax(0,1fr))}
   .pivot[data-mode="overall"] .pivot-card{grid-column:span 12}
-  .pivot[data-mode="overall"] #pivotStoreCard{grid-column:1 / span 4}
-  .pivot[data-mode="overall"] #pivotLoCard{grid-column:5 / span 4}
-  .pivot[data-mode="overall"] #pivotCustTypeCard{grid-column:9 / span 4}
-  .pivot[data-mode="overall"] #pivotPlacementCard{grid-column:9 / span 4}
-  .pivot[data-mode="overall"] #pivotCatCard{grid-column:1 / span 8}
+  .pivot[data-mode="overall"] #pivotStoreCard,
+  .pivot[data-mode="overall"] #pivotLoCard,
+  .pivot[data-mode="overall"] #pivotCustTypeCard{grid-column:1 / span 6}
+  .pivot[data-mode="overall"] #pivotCatCard,
+  .pivot[data-mode="overall"] #pivotPlacementCard{grid-column:7 / span 6}
 }
 .chart-card{position:relative;background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:12px 12px 10px;box-shadow:var(--shadow);display:flex;flex-direction:column;overflow:hidden}
 .chart-title{font-weight:700;margin-bottom:8px;color:var(--muted)}
@@ -256,16 +256,16 @@ body.has-data #tipPill{display:none !important}
       <table id="pivotTableLo" class="pivot-table"></table>
     </div>
   </div>
-  <div class="chart-card pivot-card" id="pivotCatCard">
-    <div class="chart-title">Category Performance Pivot</div>
-  <div class="pivot-body">
-      <table id="pivotTableCat" class="pivot-table"></table>
-    </div>
-  </div>
   <div class="chart-card pivot-card" id="pivotCustTypeCard">
     <div class="chart-title">Customer Search Term - TYPE Performance Pivot</div>
     <div class="pivot-body">
       <table id="pivotTableCustType" class="pivot-table"></table>
+    </div>
+  </div>
+  <div class="chart-card pivot-card" id="pivotCatCard">
+    <div class="chart-title">Category Performance Pivot</div>
+    <div class="pivot-body">
+      <table id="pivotTableCat" class="pivot-table"></table>
     </div>
   </div>
   <div class="chart-card pivot-card" id="pivotPlacementCard">
@@ -349,8 +349,8 @@ const PIVOT_CONFIG={
   overall:[
     {slot:'store', column:'ttype', fallback:'Targeting Type'},
     {slot:'lo', column:'tsub', fallback:'Targeting Sub Type'},
-    {slot:'cat', column:'tsub2', fallback:'Targeting Sub Type2'},
     {slot:'custType', column:'customerType', fallback:'Customer Search Term - TYPE'},
+    {slot:'cat', column:'tsub2', fallback:'Targeting Sub Type2'},
     {slot:'placement', column:'placement', fallback:'Placement'}
   ]
 };


### PR DESCRIPTION
## Summary
- reorder the overall pivot configuration so the left column contains Targeting Type, Targeting Sub Type, and Customer Search Term - TYPE
- adjust the markup order and layout styles so Overall Pivots render in two horizontal columns with Targeting Sub Type2 and Placement on the right

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce93eb49b08329aef1711a0b43078f