### PR TITLE
Reduce pivot gaps with masonry layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@ body.has-data #tipPill{display:none !important}
 .kpi.small{padding-right:6px}
 
 /* Pivot table */
-.pivot{padding:6px clamp(14px,3vw,26px) 20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--chartsGap);align-items:start}
+.pivot{padding:6px clamp(14px,3vw,26px) 20px;display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:var(--chartsGap);align-items:start;grid-auto-rows:var(--pivot-auto-rows,auto)}
 .pivot[data-mode="overview"] #pivotCustTypeCard,
 .pivot[data-mode="overview"] #pivotPlacementCard{display:none !important}
 .pivot[data-mode="overall"]{grid-auto-flow:dense}
@@ -339,6 +339,7 @@ function clampPanelRight(panel){ panel.style.left='0'; panel.style.right='auto';
 /* ===== elements/state ===== */
 const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),clearMonthBtn:document.getElementById('clearMonth'),tabs:{bar:document.getElementById('pivotTabsBar'),list:document.getElementById('pivotTabs')},status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')},custType:{card:document.getElementById('pivotCustTypeCard'),table:document.getElementById('pivotTableCustType')},placement:{card:document.getElementById('pivotPlacementCard'),table:document.getElementById('pivotTablePlacement')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},start:document.getElementById('startDate'),end:document.getElementById('endDate'),search:document.getElementById('searchFilter')};
 const state={ rows:[], columns:{}, monthSel:new Set(), monthOptions:[], monthDirty:false, snapshot:{}, hasData:false, activeTab:'overview' };
+let pivotLayoutFrame=null;
 if(el.tabs?.list){ el.tabs.buttons = Array.from(el.tabs.list.querySelectorAll('[data-tab]')); }
 const PIVOT_CONFIG={
   overview:[
@@ -372,6 +373,7 @@ document.addEventListener('DOMContentLoaded', () => {
     el.themeBtn.querySelector('.icon').textContent= light?'🌙':'☀️';
   }
   boot();
+  window.addEventListener('resize', debounce(()=>schedulePivotLayout(),150));
 });
 
 function setupTabs(){
@@ -874,24 +876,74 @@ function updatePivotFootSpace(table){
     const foot=table.querySelector('tfoot');
     if(!foot){
       body.style.setProperty('--pivot-foot-space','0px');
+      schedulePivotLayout();
       return;
     }
     const rect=foot.getBoundingClientRect();
     const height=Math.ceil(rect.height||0);
     const gap=Math.max(0, height+12);
     body.style.setProperty('--pivot-foot-space', `${gap}px`);
+    schedulePivotLayout();
   };
   if(typeof requestAnimationFrame==='function') requestAnimationFrame(apply);
   else apply();
+}
+
+function schedulePivotLayout(){
+  if(typeof requestAnimationFrame!=='function'){
+    updatePivotLayout();
+    return;
+  }
+  if(pivotLayoutFrame) cancelAnimationFrame(pivotLayoutFrame);
+  pivotLayoutFrame=requestAnimationFrame(()=>{
+    pivotLayoutFrame=null;
+    updatePivotLayout();
+  });
+}
+
+function updatePivotLayout(){
+  const section=el.pivot?.section;
+  if(!section || section.hidden){
+    return;
+  }
+  const cards=Array.from(section.querySelectorAll('.pivot-card'));
+  if(!cards.length){
+    section.style.removeProperty('--pivot-auto-rows');
+    return;
+  }
+  const styles=getComputedStyle(section);
+  let rowHeight=parseFloat(styles.getPropertyValue('--pivot-auto-rows'));
+  if(!Number.isFinite(rowHeight) || rowHeight<=0){
+    rowHeight=12;
+    section.style.setProperty('--pivot-auto-rows', `${rowHeight}px`);
+  }
+  const rowGap=parseFloat(styles.rowGap)||0;
+  const denom=rowHeight+rowGap;
+  cards.forEach(card=>{
+    if(card.hidden){
+      card.style.removeProperty('grid-row-end');
+      return;
+    }
+    const rect=card.getBoundingClientRect();
+    const height=rect.height;
+    if(!height){
+      card.style.removeProperty('grid-row-end');
+      return;
+    }
+    const span=Math.max(1, Math.ceil((height+rowGap)/(denom||1)));
+    card.style.gridRowEnd=`span ${span}`;
+  });
 }
 
 function renderPivotCard(target, columnLabel, agg, hasColumn){
   if(!target || !target.card || !target.table) return false;
   if(!hasColumn){
     target.card.hidden = true;
+    if(target.card.style) target.card.style.removeProperty('grid-row-end');
     target.table.innerHTML='';
     target.table.classList.remove('has-grand-total');
     updatePivotFootSpace(target.table);
+    schedulePivotLayout();
     return false;
   }
 
@@ -944,6 +996,7 @@ function renderPivotCard(target, columnLabel, agg, hasColumn){
   target.table.innerHTML = head + `<tbody>${bodyRows}</tbody><tfoot>${totalRow}</tfoot>`;
   target.table.classList.add('has-grand-total');
   updatePivotFootSpace(target.table);
+  schedulePivotLayout();
   return true;
 }
 
@@ -991,6 +1044,7 @@ function renderAll(){
       if(slot==='section') return;
       if(!usedSlots.has(slot) && target?.card){
         target.card.hidden=true;
+        target.card.style.removeProperty('grid-row-end');
         if(target.table){
           target.table.innerHTML='';
           target.table.classList.remove('has-grand-total');
@@ -1001,6 +1055,7 @@ function renderAll(){
   }
   const anyPivot=visibilities.some(Boolean);
   if(el.pivot?.section) el.pivot.section.hidden = !anyPivot;
+  schedulePivotLayout();
 }
 
 function onDownloadCsv(){


### PR DESCRIPTION
## Summary
- add masonry-style sizing to the pivot grid so cards stack without large blank bands
- compute row spans for visible pivot cards after renders and on resize to keep layout compact
- keep layout responsive by recalculating spans when cards hide, footers change, or the window resizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0cd71627483299d8e4159e3a57351