### PR TITLE
Improve KPI sparkline sizing and conversion pivot performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,7 @@ body.has-data #tipPill{display:none !important}
 .pivot-card{margin:0;width:100%}
 .pivot-card+.pivot-card{margin-top:0}
 .pivot-body{margin-top:10px;overflow-y:auto;overflow-x:hidden;max-height:clamp(360px,55vh,520px);position:relative;border-radius:10px;background:var(--panel)}
+.pivot-note{margin:2px 0 8px;color:var(--muted);font-size:12px;font-weight:600;line-height:1.35;}
 .pivot-table{width:100%;border-collapse:collapse;min-width:320px;font-variant-numeric:tabular-nums}
 .pivot-table thead th{padding:10px 12px;border-bottom:0;font-weight:700;color:var(--muted);font-size:12.5px;letter-spacing:.3px;text-transform:uppercase;position:sticky;top:0;background:var(--panel);z-index:3;text-align:right;box-shadow:inset 0 -2px 0 var(--border-strong)}
 .pivot-table thead th:first-child{text-align:left}
@@ -555,6 +556,7 @@ function deactivateCustomRange(){
 const el={header:document.getElementById('appHeader'),topLine:document.getElementById('topLine'),tipPill:document.getElementById('tipPill'),monthsWrap:document.getElementById('monthsWrap'),monthDD:document.getElementById('monthFilter'),monthList:document.getElementById('monthList'),monthCustomToggle:document.getElementById('customRangeToggle'),monthCustomPanel:document.getElementById('customRangePanel'),monthCustomStart:document.getElementById('customRangeStart'),monthCustomEnd:document.getElementById('customRangeEnd'),monthCustomApply:document.getElementById('customRangeApply'),monthCustomClear:document.getElementById('customRangeClear'),tabs:{bar:document.getElementById('pivotTabsBar'),list:document.getElementById('pivotTabs')},status:document.getElementById('statusArea'),kpis:document.getElementById('kpiSection'),pivot:{section:document.getElementById('pivotSection'),store:{card:document.getElementById('pivotStoreCard'),table:document.getElementById('pivotTableStore')},lo:{card:document.getElementById('pivotLoCard'),table:document.getElementById('pivotTableLo')},cat:{card:document.getElementById('pivotCatCard'),table:document.getElementById('pivotTableCat')},custType:{card:document.getElementById('pivotCustTypeCard'),table:document.getElementById('pivotTableCustType')},placement:{card:document.getElementById('pivotPlacementCard'),table:document.getElementById('pivotTablePlacement')},campaign:{card:document.getElementById('pivotCampaignCard'),table:document.getElementById('pivotTableCampaign')},portfolio:{card:document.getElementById('pivotPortfolioCard'),table:document.getElementById('pivotTablePortfolio')},conversionSt:{card:document.getElementById('pivotConversionStCard'),table:document.getElementById('pivotTableConversionSt')},conversionAsin:{card:document.getElementById('pivotConversionAsinCard'),table:document.getElementById('pivotTableConversionAsin')}},pickLocalBtn:document.getElementById('pickLocalBtn'),fileInput:document.getElementById('fileInput'),dlCsv:document.getElementById('downloadCsvBtn'),openFiltersBtn:document.getElementById('openFilters'),resetFiltersBtn:document.getElementById('resetFilters'),modal:document.getElementById('filtersModal'),closeFiltersBtn:document.getElementById('closeFilters'),cancelFiltersBtn:document.getElementById('cancelFilters'),applyFiltersBtn:document.getElementById('applyFilters'),clearAllBtn:document.getElementById('clearAll'),filters:document.getElementById('filtersSection'),themeBtn:document.getElementById('themeToggle'),empty:document.getElementById('emptyState'),emptyOpen:document.getElementById('emptyOpenLink'),kpi:{spend:document.getElementById('kpiSpend'),revenue:document.getElementById('kpiRevenue'),acos:document.getElementById('kpiACOS'),clicks:document.getElementById('kpiClicks'),impr:document.getElementById('kpiImpr'),ctr:document.getElementById('kpiCTR'),roas:document.getElementById('kpiROAS'),avgcpc:document.getElementById('kpiAvgCPC')},dd:{category:document.getElementById('categoryMS'),store:document.getElementById('storeMS'),lo:document.getElementById('loMS'),ttype:document.getElementById('ttypeMS'),tsub:document.getElementById('tsubMS'),tsub2:document.getElementById('tsub2MS'),campaign:document.getElementById('campaignMS'),portfolio:document.getElementById('portfolioMS')},search:document.getElementById('searchFilter')};
 const state={ rows:[], columns:{}, monthSel:new Set(), monthOptions:[], monthDirty:false, snapshot:{}, hasData:false, activeTab:'overview', customRange:{start:null,end:null,active:false}, dateBounds:{min:null,max:null}, lastTabIndex:0 };
 const TAB_ORDER=['overview','overall','campaignPortfolio','conversion'];
+const MAX_CONVERSION_ROWS=500;
 const kpiSparkCache=new Map();
 let lastKpiSeries=null;
 let pivotLayoutFrame=null;
@@ -728,6 +730,11 @@ function setHasData(has){
     if(el.monthCustomToggle) el.monthCustomToggle.disabled = state.monthOptions.length===0;
     if(el.tabs?.bar) el.tabs.bar.hidden=false;
     if(el.tipPill) el.tipPill.hidden=true;
+    if(lastKpiSeries){
+      const redraw=()=>updateKpiSparks(lastKpiSeries);
+      if(typeof requestAnimationFrame==='function'){ requestAnimationFrame(redraw); }
+      else redraw();
+    }
   }else{
     if(el.topLine) el.topLine.style.display='none';
     if(el.kpis) el.kpis.hidden=true;
@@ -1291,16 +1298,20 @@ function updateKpiSparks(series){
   });
 }
 
-function finalizeAgg(map){
+function finalizeAgg(map, limit){
   if(!(map instanceof Map) || map.size===0){
-    return {labels:[], spend:[], sales:[], acos:[]};
+    return {labels:[], spend:[], sales:[], acos:[], total:0, truncated:false, totalSpend:0, totalSales:0, limit:null};
   }
   const entries=[];
+  let totalSpend=0;
+  let totalSales=0;
   map.forEach((value,label)=>{
     const spend=+value.spend||0;
     const sales=+value.sales||0;
     const acos=sales>0 ? spend/sales : (spend>0 ? Infinity : NaN);
     entries.push({label:String(label), spend, sales, acos});
+    totalSpend+=spend;
+    totalSales+=sales;
   });
   const sortValue=v=>{
     if(Number.isNaN(v)) return Number.NEGATIVE_INFINITY;
@@ -1316,11 +1327,19 @@ function finalizeAgg(map){
     if(bAcos<aAcos) return -1;
     return String(a.label).localeCompare(String(b.label));
   });
+  const maxRows=(Number.isFinite(limit)&&limit>0)?Math.floor(limit):null;
+  const truncated=!!(maxRows && entries.length>maxRows);
+  const output=truncated?entries.slice(0,maxRows):entries;
   return {
-    labels:entries.map(e=>e.label),
-    spend:entries.map(e=>e.spend),
-    sales:entries.map(e=>e.sales),
-    acos:entries.map(e=>e.acos)
+    labels:output.map(e=>e.label),
+    spend:output.map(e=>e.spend),
+    sales:output.map(e=>e.sales),
+    acos:output.map(e=>e.acos),
+    total:entries.length,
+    truncated,
+    totalSpend,
+    totalSales,
+    limit:maxRows
   };
 }
 
@@ -1411,6 +1430,28 @@ function updatePivotLayout(){
   });
 }
 
+function setPivotNote(card, message){
+  if(!card) return;
+  let note=card.querySelector('.pivot-note');
+  if(message){
+    if(!note){
+      note=document.createElement('div');
+      note.className='pivot-note';
+      const body=card.querySelector('.pivot-body');
+      if(body && body.parentNode===card){
+        card.insertBefore(note, body);
+      }else{
+        card.appendChild(note);
+      }
+    }
+    note.textContent=message;
+    note.hidden=false;
+  }else if(note){
+    note.textContent='';
+    note.hidden=true;
+  }
+}
+
 function renderPivotCard(target, columnLabel, agg, hasColumn){
   if(!target || !target.card || !target.table) return false;
   if(!hasColumn){
@@ -1420,6 +1461,7 @@ function renderPivotCard(target, columnLabel, agg, hasColumn){
     target.table.classList.remove('has-grand-total');
     updatePivotFootSpace(target.table);
     schedulePivotLayout();
+    setPivotNote(target.card, '');
     return false;
   }
 
@@ -1435,6 +1477,7 @@ function renderPivotCard(target, columnLabel, agg, hasColumn){
     target.table.innerHTML = head + `<tbody><tr><td colspan="5" class="pivot-empty">No ${safeColumn} data for current filters.</td></tr></tbody>`;
     target.table.classList.remove('has-grand-total');
     updatePivotFootSpace(target.table);
+    setPivotNote(target.card, '');
     return true;
   }
 
@@ -1459,9 +1502,23 @@ function renderPivotCard(target, columnLabel, agg, hasColumn){
         return sales>0 ? spend/sales : (spend>0 ? Infinity : NaN);
       });
 
-  const totalSpend = spendVals.reduce((sum,val)=>sum+val,0);
-  const totalSales = salesVals.reduce((sum,val)=>sum+val,0);
+  const totalSpend = Number.isFinite(agg?.totalSpend) ? agg.totalSpend : spendVals.reduce((sum,val)=>sum+val,0);
+  const totalSales = Number.isFinite(agg?.totalSales) ? agg.totalSales : salesVals.reduce((sum,val)=>sum+val,0);
   const totalAcos = totalSales>0 ? totalSpend/totalSales : NaN;
+
+  const truncatedNote = agg?.truncated ? (()=>{
+    const totalCount=Number.isFinite(agg.total)?agg.total:labels.length;
+    const limit=Number.isFinite(agg.limit)?agg.limit:labels.length;
+    if(totalCount<=labels.length) return '';
+    const totalStr=totalCount.toLocaleString();
+    const limitStr=limit.toLocaleString();
+    return `Showing top ${limitStr} of ${totalStr} ${displayName} results. Totals include all filtered rows.`;
+  })() : '';
+  if(truncatedNote){
+    setPivotNote(target.card, truncatedNote);
+  }else{
+    setPivotNote(target.card, '');
+  }
 
   const finiteAcos = acosVals.filter(Number.isFinite);
   if(isFinite(totalAcos)) finiteAcos.push(totalAcos);
@@ -1545,7 +1602,7 @@ function renderConversionPivots(rows, spendKey, salesKey){
 
   const renderBucket=(target,map,labelSuffix)=>{
     if(!target) return false;
-    const agg=finalizeAgg(map);
+    const agg=finalizeAgg(map, MAX_CONVERSION_ROWS);
     return renderPivotCard(target, `${baseLabel} (${labelSuffix})`, agg, true);
   };
 


### PR DESCRIPTION
## Summary
- ensure KPI sparklines redraw once data becomes visible so their line length stays consistent after interactions
- cap ST-ASIN conversion pivots to the top 500 rows while keeping totals accurate and showing a helper note about the truncation
- add reusable pivot note styling/logic to surface the truncation message without disturbing layout

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d12d3a1c448329a26d272b4b7825d6