### PR TITLE
Fix missing pivot note helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -1935,6 +1935,27 @@ function pivotSortWeight(value){
 
 }
 
+function setPivotNote(card, text){
+  if(!card) return;
+  const message=(text==null?'':String(text)).trim();
+  let note=card.querySelector('.pivot-note');
+  if(!message){
+    if(note) note.remove();
+    return;
+  }
+  if(!note){
+    note=document.createElement('div');
+    note.className='pivot-note';
+    const body=card.querySelector('.pivot-body');
+    if(body && body.parentNode===card){
+      card.insertBefore(note, body);
+    }else{
+      card.appendChild(note);
+    }
+  }
+  note.textContent=message;
+}
+
 function renderPivotCard(target, columnLabel, agg, hasColumn){
   if(!target || !target.card || !target.table) return false;
   if(!hasColumn){


### PR DESCRIPTION
## Summary
- add the missing `setPivotNote` helper so pivot cards can show or hide truncation notes
- prevent the ReferenceError that stopped the default workbook from loading

## Testing
- browser_container.run_playwright_script (chromium)

------
https://chatgpt.com/codex/tasks/task_e_68d13a9f8840832985ab0b295b308e71