### PR TITLE
Show checkboxes and select-all control in term search filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,17 +72,19 @@ button:disabled{opacity:.5;cursor:not-allowed}
 .dd-search-mode .dd-search-summary[data-state="all"]{display:none}
 .dd-search-mode .dd-panel{position:absolute;top:calc(100% + 8px);left:0;right:0;background:var(--panel);border:1px solid var(--border);border-radius:12px;box-shadow:var(--shadow);max-height:360px;overflow:auto;z-index:40}
 .dd-search-mode:not(.open) .dd-panel{display:none}
-.dd-search-mode .dd-head{display:none}
+.dd-search-mode .dd-head{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:10px 12px;border-bottom:1px solid var(--border);position:sticky;top:0;background:var(--panel);z-index:2}
+.dd-search-mode .dd-head .select-all{display:flex;align-items:center;gap:8px;font-weight:700;color:var(--text)}
+.dd-search-mode .dd-head .select-all input[type=checkbox]{position:static;opacity:1;margin:0;accent-color:var(--accent);width:16px;height:16px}
 .dd-search-mode .dd-list{padding:6px}
 .dd-search-mode .dd-item{display:flex;align-items:center;gap:10px;padding:10px 12px;border-radius:10px;transition:background .2s ease, transform .12s ease, box-shadow .25s ease}
 .dd-search-mode .dd-item:hover{background:color-mix(in srgb,var(--chip) 85%, transparent);transform:translateY(-1px);box-shadow:0 6px 16px rgba(15,23,42,.18)}
 .dd-search-mode .dd-only{display:none}
-.dd-search-mode .dd-left{flex:1;display:flex;align-items:center;gap:10px;position:relative}
-.dd-search-mode .dd-left input[type=checkbox]{position:absolute;inset:0;opacity:0;cursor:pointer;border:0;margin:0}
+.dd-search-mode .dd-left{flex:1;display:flex;align-items:center;gap:10px}
+.dd-search-mode .dd-left input[type=checkbox]{position:static;opacity:1;cursor:pointer;border:0;margin:0;accent-color:var(--accent);width:16px;height:16px}
 .dd-search-mode .dd-text{font-weight:600;color:var(--text)}
 .dd-search-mode .dd-item.is-selected{background:color-mix(in srgb,var(--accent) 25%, var(--chip));box-shadow:0 10px 24px rgba(37,99,235,.18)}
 .dd-search-mode .dd-item.is-selected .dd-text{color:var(--accent)}
-.dd-search-mode .dd-item.is-selected .dd-text::after{content:'\2713';margin-left:6px;font-weight:700}
+.dd-search-mode .dd-item.is-selected .dd-text::after{content:none}
 .dd-search-mode .dd-count{color:var(--muted);font-size:12px}
 .dd-search-mode .dd-empty{padding:18px 12px;font-weight:600;color:var(--muted)}
 @media(max-width:900px){
@@ -2106,9 +2108,11 @@ function ddBuild(root){
     root.innerHTML = `
       <div class="dd-search-shell">
         <input type="search" class="dd-search" placeholder="${safePlaceholder}" autocomplete="off" aria-label="${safePlaceholder}"/>
-        <div class="dd-summary dd-search-summary" data-state="all">All terms</div>
       </div>
       <div class="dd-panel" hidden>
+        <div class="dd-head dd-search-head">
+          <label class="select-all"><input type="checkbox" class="dd-select-all"/><span>Select all</span></label>
+        </div>
         <div class="dd-list"></div>
         <div class="dd-empty">No results</div>
       </div>`;


### PR DESCRIPTION
## Summary
- display actual checkboxes beside each search term result and remove the extra checkmark indicator
- add a "Select all" control above filtered results and drop the inline selection summary under the search field

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4e7cd86e88329bb18742831523476