### PR TITLE
Fix Targeting ASIN info popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1050,6 +1050,13 @@ const el={
       navLabel:document.querySelector('#pivotConversionAsinCard .pivot-nav-label')
     }
   },
+  skuPopup:{
+    root:document.getElementById('skuPopup'),
+    card:document.getElementById('skuPopupCard'),
+    title:document.getElementById('skuPopupTitle'),
+    body:document.getElementById('skuPopupBody'),
+    close:document.getElementById('skuPopupClose')
+  },
   pickLocalBtn:document.getElementById('pickLocalBtn'),
   fileInput:document.getElementById('fileInput'),
   dlCsv:document.getElementById('downloadCsvBtn'),


### PR DESCRIPTION
## Summary
- register the Targeting ASIN popup elements so the SKU dialog can be shown when info buttons are clicked

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d61ad1f79c8329acf89a9236f77d40