### PR TITLE
Fix pivot popup data access optional chaining

### DIFF
--- a/index.html
+++ b/index.html
@@ -1185,7 +1185,7 @@ function updatePivotFilterSelection(slot, dimension, rawValue, matchValue, on){
 }
 
 function buildPivotPopupOptions(context){
-  const data=context.table?._pivotData:null;
+  const data=context.table?._pivotData ?? null;
   if(!data) return [];
   const rows=Array.isArray(data.allRows) && data.allRows.length ? data.allRows : (Array.isArray(data.rows)?data.rows:[]);
   const dimension=context.dimension || null;


### PR DESCRIPTION
## Summary
- replace the malformed optional chaining expression that read pivot popup data with a nullish coalescing fallback so parsing succeeds
- restore default workbook loading and the Open XLSX picker by letting the script execute without syntax errors

## Testing
- node - <<'NODE' ...
- playwright script to load index.html

------
https://chatgpt.com/codex/tasks/task_e_68d6457b0a008329a1fd66b19ce2c077